### PR TITLE
refactor: optimize build system security flags

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -3,6 +3,10 @@
 include /usr/share/dpkg/default.mk
 
 export QT_SELECT = qt6
+export DEB_BUILD_MAINT_OPTIONS = hardening=+all
+export DEB_CFLAGS_MAINT_APPEND = -Wall
+export DEB_CXXFLAGS_MAINT_APPEND = -Wall
+export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed -Wl,-z,relro -Wl,-z,now -Wl,-z,noexecstack -Wl,-E
 
 PACK_VER = $(shell echo $(DEB_VERSION_UPSTREAM) | awk -F'[+_~-]' '{print $$1}')
 
@@ -10,4 +14,4 @@ PACK_VER = $(shell echo $(DEB_VERSION_UPSTREAM) | awk -F'[+_~-]' '{print $$1}')
 	dh $@ --parallel
 
 override_dh_auto_configure:
-	dh_auto_configure -- -DVERSION=$(PACK_VER) -DCMAKE_CXX_FLAGS="-Wl,--as-needed"
+	dh_auto_configure -- -DVERSION=$(PACK_VER)


### PR DESCRIPTION
1. Removed redundant security flags from CMakeLists.txt since they are now handled by debian/rules
2. Added comprehensive security hardening flags in debian/rules using DEB_BUILD_MAINT_OPTIONS
3. Standardized compiler flag handling across all CMakeLists.txt files by using ${CMAKE_CXX_FLAGS} consistently
4. Kept -g flag for debugging but moved it to be appended to existing flags

The changes centralize security flag management in the Debian build system rather than having them scattered across multiple CMake files. This makes the build configuration more maintainable and consistent with Debian packaging standards.

refactor: 优化构建系统安全标志

1. 从 CMakeLists.txt 中移除冗余的安全标志，现在由 debian/rules 统一处理
2. 在 debian/rules 中使用 DEB_BUILD_MAINT_OPTIONS 添加全面的安全加固标志
3. 通过统一使用 ${CMAKE_CXX_FLAGS} 标准化所有 CMakeLists.txt 文件中的编 译器标志处理
4. 保留 -g 调试标志但改为追加到现有标志中

这些变更将安全标志管理集中到 Debian 构建系统中，而不是分散在多个 CMake
文件中，使构建配置更易维护且符合 Debian 打包标准。

## Summary by Sourcery

Centralize security flag management in the Debian build system by removing redundant flags from CMakeLists.txt, adding comprehensive hardening options in debian/rules, and standardizing compiler flag usage across all CMake projects.

Enhancements:
- Remove redundant security flags from CMakeLists.txt.
- Standardize compiler flag handling across all CMakeLists.txt via ${CMAKE_CXX_FLAGS}.
- Retain and append the -g debug flag to existing compiler flags.

Build:
- Add comprehensive security hardening flags in debian/rules via DEB_BUILD_MAINT_OPTIONS.