### PR TITLE
chore: bump version to 1.0.8

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-services (1.0.8) unstable; urgency=medium
+
+  * fix: add time-based sorting for wallpaper files
+
+ -- YeShanShan <yeshanshan@uniontech.com>  Thu, 31 Jul 2025 19:43:28 +0800
+
 dde-services (1.0.7) unstable; urgency=medium
 
   * refactor: optimize build system security flags


### PR DESCRIPTION
update changelog to 1.0.8