### PR TITLE
chore: add oom-adjust-score plugin

### DIFF
--- a/src/plugin-qt/CMakeLists.txt
+++ b/src/plugin-qt/CMakeLists.txt
@@ -2,5 +2,6 @@
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
+add_subdirectory("OOMScoreAdjust")
 add_subdirectory("thememanager")
 add_subdirectory("wallpaperslideshow")

--- a/src/plugin-qt/OOMScoreAdjust/CMakeLists.txt
+++ b/src/plugin-qt/OOMScoreAdjust/CMakeLists.txt
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
+cmake_minimum_required(VERSION 3.13)
+
+set(BIN_NAME "OOMScoreAdjust")
+
+project(${BIN_NAME})
+
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+
+include(GNUInstallDirs)
+file(GLOB_RECURSE SRCS "*.h" "*.cpp")
+
+find_package(Qt${QT_VERSION_MAJOR} ${REQUIRED_QT_VERSION} REQUIRED COMPONENTS Core DBus)
+find_package(Dtk${DTK_VERSION_MAJOR} REQUIRED COMPONENTS Core)
+
+add_library(${BIN_NAME} MODULE
+    ${SRCS}
+)
+
+target_include_directories(${BIN_NAME} PUBLIC
+  Qt${QT_VERSION_MAJOR}::Core
+  Qt${QT_VERSION_MAJOR}::DBus
+  ${DtkCore_INCLUDE_DIRS}
+)
+
+target_link_libraries(${BIN_NAME} PRIVATE
+  Qt${QT_VERSION_MAJOR}::Core
+  Qt${QT_VERSION_MAJOR}::DBus
+  Dtk${DTK_VERSION_MAJOR}::Core
+)
+
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/OOM-Score-Adjust.json DESTINATION share/deepin-service-manager/system/)
+install(FILES org.deepin.service.OOMScoreAdjust.conf DESTINATION share/dbus-1/system.d/)
+install(FILES ./configs/oom-score-adjust.desktop DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/xdg/autostart/)
+install(TARGETS ${BIN_NAME} LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/deepin-service-manager/)
+install(FILES ./configs/org.deepin.service.manager.oom-score-adjust.json DESTINATION share/dsg/configs/org.deepin.service.manager/)
+install(FILES ./configs/org.deepin.OOMScoreAdjust.service DESTINATION share/dbus-1/system-services/)

--- a/src/plugin-qt/OOMScoreAdjust/OOM-Score-Adjust.json
+++ b/src/plugin-qt/OOMScoreAdjust/OOM-Score-Adjust.json
@@ -1,0 +1,14 @@
+{
+  "name": "org.deepin.OOMScoreAdjust",
+  "libPath": "libOOMScoreAdjust.so",
+  "group": "core",
+  "policyStartType": "OnDemand",
+  "pluginType": "qt",
+  "startDelay": 0,
+  "idleTime": 5,
+  "policy": [
+    {
+      "path": "/org/deepin/OOMScoreAdjust"
+    }
+  ]
+}

--- a/src/plugin-qt/OOMScoreAdjust/configs/oom-score-adjust.desktop
+++ b/src/plugin-qt/OOMScoreAdjust/configs/oom-score-adjust.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=OOMScoreAdjust
+Comment=OOMScoreAdjust
+Encoding=UTF-8
+Exec=dbus-send --system --dest=org.deepin.OOMScoreAdjust --type=method_call --print-reply /org/deepin/OOMScoreAdjust org.freedesktop.DBus.Peer.Ping
+NoDisplay=true
+OnlyShowIn=Deepin
+Type=Application
+X-Deepin-Vendor=user-custom

--- a/src/plugin-qt/OOMScoreAdjust/configs/org.deepin.OOMScoreAdjust.service
+++ b/src/plugin-qt/OOMScoreAdjust/configs/org.deepin.OOMScoreAdjust.service
@@ -1,0 +1,5 @@
+[D-BUS Service]
+Name=org.deepin.OOMScoreAdjust
+Exec=/usr/bin/deepin-service-manager -n org.deepin.OOMScoreAdjust
+user=root
+SystemdService=deepin-service-plugin@org.deepin.OOMScoreAdjust.service

--- a/src/plugin-qt/OOMScoreAdjust/configs/org.deepin.service.manager.oom-score-adjust.json
+++ b/src/plugin-qt/OOMScoreAdjust/configs/org.deepin.service.manager.oom-score-adjust.json
@@ -1,0 +1,28 @@
+{
+    "magic":"dsg.config.meta",
+    "version":"1.0",
+    "contents":{
+        "protectionProcess":{
+            "value": ["/usr/bin/dde-session", "/usr/bin/kwin_x11", "/usr/sbin/lightdm", "/usr/lib/xorg/Xorg"],
+            "serial": 0,
+            "flags":["global"],
+            "name":"ProtectionProcess",
+            "name[zh_CN]":"保护进程",
+            "description[zh_CN]":"修改adj的值，以防止被OOM机制杀掉",
+            "description":"",
+            "permissions":"readonly",
+            "visibility":"private"
+        },
+        "enabled":{
+            "value": true,
+            "serial": 0,
+            "flags":["global"],
+            "name":"Enabled",
+            "name[zh_CN]":"是否启用",
+            "description[zh_CN]":"true表示启用，false表示不启用",
+            "description":"",
+            "permissions":"readonly",
+            "visibility":"private"
+        }
+    }
+}

--- a/src/plugin-qt/OOMScoreAdjust/org.deepin.service.OOMScoreAdjust.conf
+++ b/src/plugin-qt/OOMScoreAdjust/org.deepin.service.OOMScoreAdjust.conf
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?> <!-- -*- XML -*- -->
+
+<!DOCTYPE busconfig PUBLIC
+ "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+
+  <!-- Only root can own the service -->
+  <policy user="root">
+    <allow own="org.deepin.OOMScoreAdjust"/>
+    <allow send_destination="org.deepin.OOMScoreAdjust"/>
+  </policy>
+
+  <!-- Allow anyone to invoke methods on the interfaces -->
+  <policy context="default">
+    <allow send_destination="org.deepin.OOMScoreAdjust"/>
+  </policy>
+
+</busconfig>

--- a/src/plugin-qt/OOMScoreAdjust/plugin.cpp
+++ b/src/plugin-qt/OOMScoreAdjust/plugin.cpp
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "service.h"
+
+#include <QDBusConnection>
+
+static Service *service = nullptr;
+
+extern "C" int DSMRegister(const char *name, void *data)
+{
+    (void)name;
+    service = new Service();
+    QDBusConnection::RegisterOptions opts = QDBusConnection::ExportAllSlots
+            | QDBusConnection::ExportAllSignals | QDBusConnection::ExportAllProperties;
+
+    auto connection = reinterpret_cast<QDBusConnection *>(data);
+    connection->registerObject("/org/deepin/OOMScoreAdjust", service, opts);
+    return 0;
+}
+
+// 该函数用于资源释放
+// 非常驻插件必须实现该函数，以防内存泄漏
+extern "C" int DSMUnRegister(const char *name, void *data)
+{
+    (void)name;
+    (void)data;
+    service->deleteLater();
+    service = nullptr;
+    return 0;
+}

--- a/src/plugin-qt/OOMScoreAdjust/service.cpp
+++ b/src/plugin-qt/OOMScoreAdjust/service.cpp
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "service.h"
+#include <qlogging.h>
+
+#include <DConfig>
+
+#include <QFile>
+#include <QTextStream>
+#include <QDir>
+#include <QDebug>
+#include <QStringList>
+
+#include <sys/stat.h>
+#include <unistd.h>
+
+static QString readNamespaceLinkTarget(const QString &path)
+{
+    char target[PATH_MAX];
+    ssize_t len;
+
+    len = readlink(path.toStdString().c_str(), target, sizeof(target) - 1);
+    if (len == -1) {
+        qWarning() << "Failed to read link" << path << ":" << strerror(errno);
+        return "";
+    }
+
+    target[len] = '\0';
+    return QString::fromStdString(std::string(target));
+}
+
+static QList<int> getPidByName(const QString &processName)
+{
+    QList<int> pids;
+    const QString &systemdMnt = readNamespaceLinkTarget("/proc/1/ns/mnt");
+    if (systemdMnt.isEmpty()) {
+        qWarning() << "Failed to get systemd mount namespace";
+        return pids;
+    }
+    QDir procDir("/proc");
+    // 遍历 /proc 目录下的所有子目录（即所有的 PID）
+    const QStringList &entries = procDir.entryList(QDir::Dirs | QDir::NoDotAndDotDot);
+    for (const QString &entry : entries) {
+        bool ok;
+        int pid = entry.toInt(&ok);
+        if (!ok) {
+            continue; // 不是有效的 PID
+        }
+
+        const QString &exe = QString("/proc/%1/exe").arg(pid);
+        if (!QFileInfo(exe).isSymLink() || !QFileInfo::exists(exe))
+            continue;
+        const QString &exeFilePath = QFileInfo(exe).symLinkTarget();
+        if (exeFilePath != processName)
+            continue;
+        // 检查是否在 systemd 的 mount namespace 中
+        const QString &mnt = readNamespaceLinkTarget(QString("/proc/%1/ns/mnt").arg(pid));
+        if (mnt == systemdMnt) {
+            pids << pid;
+            qDebug() << "Found process:" << processName << "with PID:" << pid;
+        }
+    }
+
+    return pids;
+}
+
+static int setOOMScoreAdj(int pid)
+{
+    // 构造 /proc/<pid>/oom_score_adj 的路径
+    const QString &procPath = QDir::toNativeSeparators(QString("/proc/%1/oom_score_adj").arg(pid));
+    QFile file(procPath);
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+        qWarning() << "Failed to open" << procPath << "for writing:" << file.errorString();
+        return -1;
+    }
+
+    // 写入 oom_score_adj 值
+    QTextStream out(&file);
+    out << -999;
+    file.close();
+
+    // 检查写入是否成功
+    if (out.status() != QTextStream::Ok) {
+        qWarning() << "Failed to write to" << procPath << ":" << out.status();
+        return -1;
+    }
+
+    return 0;
+}
+
+Service::Service(QObject *parent)
+    : QObject(parent)
+{
+    InitOOMScoreAdjust();
+}
+
+void Service::InitOOMScoreAdjust()
+{
+    auto config = Dtk::Core::DConfig::create("org.deepin.service.manager", "org.deepin.service.manager.oom-score-adjust", "", this);
+    if (!config || !config->isValid()) {
+        qWarning() << "org.deepin.service.manager.oom-score-adjust is not valid";
+        return;
+    }
+
+    if (!config->value("enabled").toBool()) {
+        qWarning() << "org.deepin.OOMScoreAdjust is disabled";
+        return;
+    }
+    const QStringList &protectionProcessList = config->value("protectionProcess").toStringList();
+    // 修改配置中OOMScoreAdjust的值
+    for (const QString &process : protectionProcessList) {
+        const QList<int> &pids = getPidByName(process);
+        if (pids.size() > 0) {
+            for (int processPid : pids) {
+                int res = setOOMScoreAdj(processPid);
+                if (res != 0) {
+                    qWarning() << "Failed to set oom_score_adj for process" << process << processPid;
+                }
+            }
+        } else {
+            qWarning() << "Failed to find the pid for process" << process;
+        }
+    }
+
+    config->deleteLater();
+}

--- a/src/plugin-qt/OOMScoreAdjust/service.h
+++ b/src/plugin-qt/OOMScoreAdjust/service.h
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef SERVICE_H
+#define SERVICE_H
+
+#include <QObject>
+
+class Service : public QObject
+{
+    Q_OBJECT
+    Q_CLASSINFO("D-Bus Interface", "org.deepin.OOMScoreAdjust")
+
+public:
+    explicit Service(QObject *parent = 0);
+
+public Q_SLOTS:
+    void InitOOMScoreAdjust();
+};
+
+#endif // SERVICE_H


### PR DESCRIPTION
moved from deepin-service-manager

Log: as title
Pms: TASK-380689

## Summary by Sourcery

Introduce a new OOMScoreAdjust plugin for deepin-service-manager that reads its configuration, discovers the specified processes in the systemd mount namespace, and sets their oom_score_adj to -999 via a D-Bus interface

New Features:
- Add new OOMScoreAdjust plugin module to adjust oom_score_adj for configured processes
- Expose OOMScoreAdjust service over D-Bus with registration and unregistration hooks

Enhancements:
- Implement process discovery by executable path within the systemd mount namespace
- Load plugin settings via Dtk::Core::DConfig to control enabling and protected process list

Build:
- Update CMakeLists to include the OOMScoreAdjust directory and install rules
- Install D-Bus busconfig, service, JSON config, and desktop autostart files for the plugin