### PR TITLE
chore: bump version to 1.0.9

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-services (1.0.9) unstable; urgency=high
+
+  * Chore: add oom-adjust-score plugin
+
+ -- zyz <zhaoyingzhen@uniontech.com>  Thu, 21 Aug 2025 21:52:48 +0800
+
 dde-services (1.0.8) unstable; urgency=medium
 
   * fix: add time-based sorting for wallpaper files


### PR DESCRIPTION
as title

Log: as title

## Summary by Sourcery

Chores:
- Update version number to 1.0.9 in changelog